### PR TITLE
Bugfix/transaction 'from' timestamp in ms

### DIFF
--- a/revolut/__init__.py
+++ b/revolut/__init__.py
@@ -185,7 +185,6 @@ class Revolut:
 
     def get_account_transactions(self, from_date):
         """ Get the account transactions and return as json """
-        wallet_id = self.get_wallet_id()
         from_date_ts = from_date.timestamp()
         path = _URL_GET_TRANSACTIONS + '?from={from_date_ts}&walletId={wallet_id}'.format(
             from_date_ts=int(from_date_ts) * 1000,

--- a/revolut/__init__.py
+++ b/revolut/__init__.py
@@ -188,7 +188,7 @@ class Revolut:
         wallet_id = self.get_wallet_id()
         from_date_ts = from_date.timestamp()
         path = _URL_GET_TRANSACTIONS + '?from={from_date_ts}&walletId={wallet_id}'.format(
-            from_date_ts=int(from_date_ts),
+            from_date_ts=int(from_date_ts) * 1000,
             wallet_id=self.get_wallet_id()
         )
         ret = self.client._get(path)


### PR DESCRIPTION
Revolut is taking transactions time in miliseconds, so to get correct transactions list needs to modify the timestamp value which is in seconds